### PR TITLE
Fix realm creation status code

### DIFF
--- a/src/login_server/web_client.cpp
+++ b/src/login_server/web_client.cpp
@@ -245,7 +245,7 @@ namespace mmo
 			if (*result == RealmCreationResult::RealmNameAlreadyInUse)
 			{
 				response.setStatus(net::http::OutgoingAnswer::Conflict);
-				SendJsonResponse(response, "{\"status\":\"ACCOUNT_NAME_ALREADY_IN_USE\", \"message\":\"Realm name already in use\"}");
+                                SendJsonResponse(response, "{\"status\":\"REALM_NAME_ALREADY_IN_USE\", \"message\":\"Realm name already in use\"}");
 				return;
 			}
 


### PR DESCRIPTION
## Summary
- fix incorrect status code in web client's realm creation response

## Testing
- `cmake -S . -B build -DMMO_BUILD_TESTS=ON` *(fails: The source directory /workspace/mmo/deps/recastnavigation does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_684021296f60832c9342df41a8a619a0