### PR TITLE
Add GM dev commands: pos, targetinfo, morph, kill, revive

### DIFF
--- a/src/mmo_client/game_states/world_state.cpp
+++ b/src/mmo_client/game_states/world_state.cpp
@@ -1377,6 +1377,16 @@ namespace mmo
 								 { Command_Speed(cmd, args); }, ConsoleCommandCategory::Gm, "Sets your movement speed to the new value in meters per second.");
 		Console::RegisterCommand("checklos", [this](const std::string &cmd, const std::string &args)
 								 { Command_CheckLineOfSight(cmd, args); }, ConsoleCommandCategory::Gm, "Performs a server-side line of sight check from your position to the selected target and visualizes the result.");
+		Console::RegisterCommand("pos", [this](const std::string &cmd, const std::string &args)
+								 { Command_Pos(cmd, args); }, ConsoleCommandCategory::Gm, "Prints your current map ID, position (x, y, z) and facing angle to the console.");
+		Console::RegisterCommand("targetinfo", [this](const std::string &cmd, const std::string &args)
+								 { Command_TargetInfo(cmd, args); }, ConsoleCommandCategory::Gm, "Prints GUID, entry, level, health and position of the selected target.");
+		Console::RegisterCommand("morph", [this](const std::string &cmd, const std::string &args)
+								 { Command_Morph(cmd, args); }, ConsoleCommandCategory::Gm, "Changes the display model of the selected unit (or yourself) to the given display id.");
+		Console::RegisterCommand("kill", [this](const std::string &cmd, const std::string &args)
+								 { Command_Kill(cmd, args); }, ConsoleCommandCategory::Gm, "Instantly kills the selected target (or yourself if nothing is selected).");
+		Console::RegisterCommand("revive", [this](const std::string &cmd, const std::string &args)
+								 { Command_Revive(cmd, args); }, ConsoleCommandCategory::Gm, "Revives the selected dead unit at its current position (or yourself if nothing is selected).");
 #endif
 	}
 
@@ -1396,6 +1406,11 @@ namespace mmo
 		Console::UnregisterCommand("summon");
 		Console::UnregisterCommand("speed");
 		Console::UnregisterCommand("checklos");
+		Console::UnregisterCommand("pos");
+		Console::UnregisterCommand("targetinfo");
+		Console::UnregisterCommand("morph");
+		Console::UnregisterCommand("kill");
+		Console::UnregisterCommand("revive");
 #endif
 
 		m_tradeClient.Shutdown();

--- a/src/mmo_client/game_states/world_state.h
+++ b/src/mmo_client/game_states/world_state.h
@@ -422,6 +422,16 @@ namespace mmo
 		void Command_Summon(const std::string &cmd, const std::string &args) const;
 
 		void Command_Port(const std::string &cmd, const std::string &args) const;
+
+		void Command_Pos(const std::string &cmd, const std::string &args) const;
+
+		void Command_TargetInfo(const std::string &cmd, const std::string &args) const;
+
+		void Command_Morph(const std::string &cmd, const std::string &args) const;
+
+		void Command_Kill(const std::string &cmd, const std::string &args) const;
+
+		void Command_Revive(const std::string &cmd, const std::string &args) const;
 #endif
 
 	private:

--- a/src/mmo_client/game_states/world_state_commands.cpp
+++ b/src/mmo_client/game_states/world_state_commands.cpp
@@ -341,5 +341,107 @@ namespace mmo
 
 		m_realmConnector.CheckLineOfSight(targetGuid);
 	}
+
+	void WorldState::Command_Pos(const std::string &cmd, const std::string &args) const
+	{
+		const auto player = ObjectMgr::GetActivePlayer();
+		if (!player)
+		{
+			ELOG("pos: no active player");
+			return;
+		}
+
+		const Vector3& pos = player->GetPosition();
+		const float facingDeg = player->GetFacing().GetValueDegrees();
+		const uint32 mapId = player->GetMapId();
+		DLOG("Position: map=" << mapId
+			<< " x=" << pos.x
+			<< " y=" << pos.y
+			<< " z=" << pos.z
+			<< " facing=" << facingDeg);
+	}
+
+	void WorldState::Command_TargetInfo(const std::string &cmd, const std::string &args) const
+	{
+		const auto player = ObjectMgr::GetActivePlayer();
+		if (!player)
+		{
+			ELOG("targetinfo: no active player");
+			return;
+		}
+
+		const uint64 targetGuid = player->Get<uint64>(object_fields::TargetUnit);
+		if (targetGuid == 0)
+		{
+			ELOG("targetinfo: no target selected");
+			return;
+		}
+
+		const auto target = ObjectMgr::Get<GameObjectC>(targetGuid);
+		if (!target)
+		{
+			ELOG("targetinfo: target not found in object manager");
+			return;
+		}
+
+		const uint32 entry = target->Get<uint32>(object_fields::Entry);
+
+		std::ostringstream oss;
+		oss << "Target: guid=0x" << std::hex << targetGuid << std::dec
+			<< " entry=" << entry;
+
+		if (target->IsUnit())
+		{
+			const auto& unit = target->AsUnit();
+			const uint32 level = unit.Get<uint32>(object_fields::Level);
+			const uint32 health = unit.Get<uint32>(object_fields::Health);
+			const uint32 maxHealth = unit.Get<uint32>(object_fields::MaxHealth);
+			const Vector3& pos = unit.GetPosition();
+			oss << " level=" << level
+				<< " hp=" << health << "/" << maxHealth
+				<< " pos=(" << pos.x << ", " << pos.y << ", " << pos.z << ")"
+				<< " name=\"" << unit.GetName() << "\"";
+		}
+
+		if (target->GetTypeId() == ObjectTypeId::Player)
+		{
+			oss << " [PLAYER]";
+		}
+		else if (target->GetTypeId() == ObjectTypeId::Unit)
+		{
+			oss << " [CREATURE]";
+		}
+
+		DLOG(oss.str());
+	}
+
+	void WorldState::Command_Morph(const std::string &cmd, const std::string &args) const
+	{
+		const auto tokens = ParseCommandArgs(args);
+		if (tokens.empty())
+		{
+			ELOG("Usage: morph <displayId>");
+			return;
+		}
+
+		uint32 displayId = 0;
+		if (!ParseUInt(tokens[0], displayId))
+		{
+			ELOG("Invalid display id: " + tokens[0]);
+			return;
+		}
+
+		m_realmConnector.Morph(displayId);
+	}
+
+	void WorldState::Command_Kill(const std::string &cmd, const std::string &args) const
+	{
+		m_realmConnector.KillTarget();
+	}
+
+	void WorldState::Command_Revive(const std::string &cmd, const std::string &args) const
+	{
+		m_realmConnector.ReviveTarget();
+	}
 #endif
 }

--- a/src/mmo_client/net/realm_connector.cpp
+++ b/src/mmo_client/net/realm_connector.cpp
@@ -519,6 +519,31 @@ namespace mmo
 			});
 	}
 
+	void RealmConnector::Morph(uint32 displayId)
+	{
+		sendSinglePacket([displayId](game::OutgoingPacket& packet) {
+			packet.Start(game::client_realm_packet::CheatMorph);
+			packet << io::write<uint32>(displayId);
+			packet.Finish();
+			});
+	}
+
+	void RealmConnector::KillTarget()
+	{
+		sendSinglePacket([](game::OutgoingPacket& packet) {
+			packet.Start(game::client_realm_packet::CheatKill);
+			packet.Finish();
+			});
+	}
+
+	void RealmConnector::ReviveTarget()
+	{
+		sendSinglePacket([](game::OutgoingPacket& packet) {
+			packet.Start(game::client_realm_packet::CheatRevive);
+			packet.Finish();
+			});
+	}
+
 	void RealmConnector::CastSpell(uint32 spellId, const SpellTargetMap& targetMap)
 	{
 		sendSinglePacket([spellId, &targetMap](game::OutgoingPacket& packet) {

--- a/src/mmo_client/net/realm_connector.h
+++ b/src/mmo_client/net/realm_connector.h
@@ -269,6 +269,16 @@ namespace mmo
 
 		void SetSpeed(float speed);
 
+		/// FROM CONSOLE COMMAND: GAME MASTER only. Changes the display model of the selected unit (or the player if nothing is targeted).
+		/// @param displayId The display model id to apply.
+		void Morph(uint32 displayId);
+
+		/// FROM CONSOLE COMMAND: GAME MASTER only. Instantly kills the selected unit (or the player if nothing is targeted).
+		void KillTarget();
+
+		/// FROM CONSOLE COMMAND: GAME MASTER only. Revives a dead unit at its current position without teleporting to a bind point.
+		void ReviveTarget();
+
 		/// Sends a packet to the server to cast a specific spell. The controlled character must know the spell. This method can not be used to
 		///	cast spells from items. Instead, use the UseItem method for this instead.
 		///	@param spellId The id of the spell to cast.

--- a/src/realm_server/player.cpp
+++ b/src/realm_server/player.cpp
@@ -705,6 +705,9 @@ namespace mmo
 		case game::client_realm_packet::CheatSpeed:
 		case game::client_realm_packet::CheatWorldPort:
 		case game::client_realm_packet::CheatTeleportToPlayer:
+		case game::client_realm_packet::CheatMorph:
+		case game::client_realm_packet::CheatKill:
+		case game::client_realm_packet::CheatRevive:
 			// Require GM level 1 (basic GM)
 			if (!HasGMLevel(1))
 			{
@@ -2935,6 +2938,9 @@ namespace mmo
 			m_proxyHandlers += RegisterAutoPacketHandler(game::client_realm_packet::CheatWorldPort, *this, &Player::OnProxyPacket);
 			m_proxyHandlers += RegisterAutoPacketHandler(game::client_realm_packet::CheatSpeed, *this, &Player::OnProxyPacket);
 			m_proxyHandlers += RegisterAutoPacketHandler(game::client_realm_packet::CheatCheckLineOfSight, *this, &Player::OnProxyPacket);
+			m_proxyHandlers += RegisterAutoPacketHandler(game::client_realm_packet::CheatMorph, *this, &Player::OnProxyPacket);
+			m_proxyHandlers += RegisterAutoPacketHandler(game::client_realm_packet::CheatKill, *this, &Player::OnProxyPacket);
+			m_proxyHandlers += RegisterAutoPacketHandler(game::client_realm_packet::CheatRevive, *this, &Player::OnProxyPacket);
 #endif
 
 			RegisterPacketHandler(game::client_realm_packet::ChatMessage, *this, &Player::OnChatMessage);

--- a/src/shared/game_protocol/game_protocol.h
+++ b/src/shared/game_protocol/game_protocol.h
@@ -283,6 +283,15 @@ namespace mmo
 			/// Sent by the client to request a server-side line of sight check against the current target. Dev/debug only.
 			CheatCheckLineOfSight, // GAME MASTER
 
+			/// Sent by the client to change the display model of the selected unit (or self). Dev/debug only.
+			CheatMorph, // GAME MASTER
+
+			/// Sent by the client to instantly kill the selected unit (or self). Dev/debug only.
+			CheatKill, // GAME MASTER
+
+			/// Sent by the client to instantly revive a dead unit at its current position. Dev/debug only.
+			CheatRevive, // GAME MASTER
+
 			/// Sent by the client when the local player starts swimming (enters deep enough water).
 			/// This is the only packet permitted to add the Swimming movement flag.
 			MoveStartSwim,

--- a/src/world_server/player.cpp
+++ b/src/world_server/player.cpp
@@ -674,6 +674,15 @@ namespace mmo
 		case game::client_realm_packet::CheatCheckLineOfSight:
 			OnCheatCheckLineOfSight(opCode, buffer.size(), reader);
 			break;
+		case game::client_realm_packet::CheatMorph:
+			OnCheatMorph(opCode, buffer.size(), reader);
+			break;
+		case game::client_realm_packet::CheatKill:
+			OnCheatKill(opCode, buffer.size(), reader);
+			break;
+		case game::client_realm_packet::CheatRevive:
+			OnCheatRevive(opCode, buffer.size(), reader);
+			break;
 #endif
 
 		case game::client_realm_packet::CastSpell:

--- a/src/world_server/player.h
+++ b/src/world_server/player.h
@@ -569,6 +569,24 @@ namespace mmo
 		/// Reads the target GUID, performs an LOS check against the world nav mesh,
 		/// and sends back a DebugLineOfSightResult packet.
 		void OnCheatCheckLineOfSight(uint16 opCode, uint32 size, io::Reader& contentReader);
+
+		/// Handles the client's request to change the display model of the selected unit or the player themselves.
+		///	@param opCode The op code of the packet.
+		///	@param size The size of the packet content in bytes, excluding the packet header.
+		/// @param contentReader Reader object used to read the packets content bytes.
+		void OnCheatMorph(uint16 opCode, uint32 size, io::Reader& contentReader);
+
+		/// Handles the client's request to instantly kill the selected unit (or the player if nothing is targeted).
+		///	@param opCode The op code of the packet.
+		///	@param size The size of the packet content in bytes, excluding the packet header.
+		/// @param contentReader Reader object used to read the packets content bytes.
+		void OnCheatKill(uint16 opCode, uint32 size, io::Reader& contentReader);
+
+		/// Handles the client's request to revive a dead unit at its current position without teleporting to a bind point.
+		///	@param opCode The op code of the packet.
+		///	@param size The size of the packet content in bytes, excluding the packet header.
+		/// @param contentReader Reader object used to read the packets content bytes.
+		void OnCheatRevive(uint16 opCode, uint32 size, io::Reader& contentReader);
 #endif
 
 	private:

--- a/src/world_server/player_dev_handlers.cpp
+++ b/src/world_server/player_dev_handlers.cpp
@@ -370,6 +370,114 @@ namespace mmo
 #endif
 
 #if MMO_WITH_DEV_COMMANDS
+	void Player::OnCheatMorph(uint16 opCode, uint32 size, io::Reader& contentReader)
+	{
+		uint32 displayId;
+		if (!(contentReader >> io::read<uint32>(displayId)))
+		{
+			ELOG("Failed to read CheatMorph packet!");
+			return;
+		}
+
+		uint64 targetGuid = m_character->Get<uint64>(object_fields::TargetUnit);
+		if (targetGuid == 0)
+		{
+			targetGuid = m_character->GetGuid();
+		}
+
+		GameObjectS* object = m_worldInstance->FindObjectByGuid(targetGuid);
+		if (!object)
+		{
+			ELOG("CheatMorph: target not found in world");
+			return;
+		}
+
+		GameUnitS* unit = dynamic_cast<GameUnitS*>(object);
+		if (!unit)
+		{
+			ELOG("CheatMorph: target is not a unit");
+			return;
+		}
+
+		DLOG("Morphing unit " << log_hex_digit(targetGuid) << " to display id " << displayId);
+		unit->Set<uint32>(object_fields::DisplayId, displayId);
+	}
+#endif
+
+#if MMO_WITH_DEV_COMMANDS
+	void Player::OnCheatKill(uint16 opCode, uint32 size, io::Reader& contentReader)
+	{
+		uint64 targetGuid = m_character->Get<uint64>(object_fields::TargetUnit);
+		if (targetGuid == 0)
+		{
+			targetGuid = m_character->GetGuid();
+		}
+
+		GameObjectS* object = m_worldInstance->FindObjectByGuid(targetGuid);
+		if (!object)
+		{
+			ELOG("CheatKill: target not found in world");
+			return;
+		}
+
+		GameUnitS* unit = dynamic_cast<GameUnitS*>(object);
+		if (!unit)
+		{
+			ELOG("CheatKill: target is not a unit");
+			return;
+		}
+
+		if (!unit->IsAlive())
+		{
+			ELOG("CheatKill: target is already dead");
+			return;
+		}
+
+		DLOG("GM kill on unit " << log_hex_digit(targetGuid));
+		unit->Kill(m_character.get());
+	}
+#endif
+
+#if MMO_WITH_DEV_COMMANDS
+	void Player::OnCheatRevive(uint16 opCode, uint32 size, io::Reader& contentReader)
+	{
+		uint64 targetGuid = m_character->Get<uint64>(object_fields::TargetUnit);
+		if (targetGuid == 0)
+		{
+			targetGuid = m_character->GetGuid();
+		}
+
+		GameObjectS* object = m_worldInstance->FindObjectByGuid(targetGuid);
+		if (!object)
+		{
+			ELOG("CheatRevive: target not found in world");
+			return;
+		}
+
+		GameUnitS* unit = dynamic_cast<GameUnitS*>(object);
+		if (!unit)
+		{
+			ELOG("CheatRevive: target is not a unit");
+			return;
+		}
+
+		if (unit->IsAlive())
+		{
+			ELOG("CheatRevive: target is not dead");
+			return;
+		}
+
+		DLOG("GM revive on unit " << log_hex_digit(targetGuid));
+		unit->Set<uint32>(object_fields::Health, unit->Get<uint32>(object_fields::MaxHealth));
+		if (unit->Get<uint32>(object_fields::MaxMana) > 1)
+		{
+			unit->Set<uint32>(object_fields::Mana, unit->Get<uint32>(object_fields::MaxMana));
+		}
+		unit->StartRegeneration();
+	}
+#endif
+
+#if MMO_WITH_DEV_COMMANDS
 	void Player::OnCheatCheckLineOfSight(uint16 opCode, uint32 size, io::Reader& contentReader)
 	{
 		uint64 targetGuid = 0;


### PR DESCRIPTION
Adds five new console commands for game master testing:

- pos: prints current map ID, x/y/z position, and facing angle (client-side only, no server round-trip required)
- targetinfo: prints GUID, entry, level, HP, position, and name of the selected target using client-side object data
- morph <displayId>: changes the display model of the selected unit (or self); useful for visual testing and NPC presentation
- kill: instantly kills the selected unit (or self if nothing targeted); requires GM level 1
- revive: restores full health/mana to a dead unit at its current position without teleporting to a bind point; requires GM level 1

Server-side: added CheatMorph, CheatKill, and CheatRevive opcodes to game_protocol.h; implemented handlers in player_dev_handlers.cpp; wired dispatch in world_server/player.cpp; registered as proxy packets with GM-level checks in realm_server/player.cpp.


Claude-Session: https://claude.ai/code/session_013vurdomyMDaENtcTqR2UM8